### PR TITLE
Path from external app url will be used as base path for router

### DIFF
--- a/webapp/helpers_test.go
+++ b/webapp/helpers_test.go
@@ -97,9 +97,14 @@ func (t *testProvider) UnmarshalSession(data string) (goth.Session, error) {
 //////////////////
 // Test handler //
 //////////////////
-
 func makeHandler() (http.Handler, *serializerLog, *mapStorage) {
-	url, _ := url.Parse("http://localhost:1234")
+	return makeHandlerSubPath("")
+}
+
+func makeHandlerSubPath(path string) (http.Handler, *serializerLog, *mapStorage) {
+	url, _ := url.Parse("http://localhost:1234/")
+	url.Path = path
+
 	serializer := new(serializerLog)
 	storage := &mapStorage{
 		Data: make(map[string]*core.User),

--- a/webapp/webhandler.go
+++ b/webapp/webhandler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gorilla/mux"
 	"github.com/gorilla/pat"
 	"github.com/gorilla/sessions"
 	"github.com/hashtock/service-tools/serialize"
@@ -36,6 +37,12 @@ func Handlers(options Options) http.Handler {
 	}
 
 	m := pat.New()
+	if options.AppAddress.Path != "" {
+		r := mux.NewRouter()
+		sub := r.PathPrefix(options.AppAddress.Path).Subrouter()
+		m.Router = *sub
+	}
+
 	m.Get("/who/", auth.who)
 	m.Get("/providers/", auth.providers)
 	m.Get("/logout/", auth.logout)


### PR DESCRIPTION
Allow to serve Auth app under a certain path.

``` bash
AUTH_APP_ADDRESS=http://localhost:8080/auth/
```

Will move `/who/` to `/auth/who/` and the same for gplus callback and all other handlers
